### PR TITLE
remove gb/log package from code

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/constabulary/gb"
 	"github.com/constabulary/gb/cmd"
-	"github.com/constabulary/gb/log"
 )
 
 const DocUsage = `gb gae is a tool for managing Google Appengine applications with gb.
@@ -53,7 +52,6 @@ func main() {
 	// Setup flags
 	fs := flag.NewFlagSet("gb-gae", flag.ExitOnError)
 	fs.StringVar(&projectRoot, "R", os.Getenv("GB_PROJECT_DIR"), "set the project root")
-	fs.BoolVar(&log.Verbose, "v", log.Verbose, "enable log levels below INFO level")
 
 	err := cmd.RunCommand(fs, &cmd.Command{
 		Run: run,


### PR DESCRIPTION
https://github.com/constabulary/gb/pull/450
gb/log package is removed.

gb pickup debug flag from environment variable.
https://github.com/constabulary/gb/pull/450/files#diff-f7b71f96172c7a728f35fb31d8771becR19
